### PR TITLE
added .conf snippet to /etc/security/limits.d

### DIFF
--- a/salt/data-pipeline/config/etc-security-limits.d-20-nifi.conf
+++ b/salt/data-pipeline/config/etc-security-limits.d-20-nifi.conf
@@ -1,0 +1,6 @@
+# nifi recommended settings:
+# https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#configuration-best-practices
+*  hard  nofile  50000
+*  soft  nofile  50000
+*  hard  nproc  10000
+*  soft  nproc  10000

--- a/salt/data-pipeline/nifi.sls
+++ b/salt/data-pipeline/nifi.sls
@@ -1,5 +1,10 @@
 # https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html
-   
+
+increased security limits:
+    file.managed:
+        - name: /etc/security/limits.d/20-nifi.conf
+        - source: salt://data-pipeline/config/etc-security-limits.d-20-nifi.conf
+
 # download nifi and nifi-kit
 
 {% set nifi_dir = "/srv/nifi-1.7.1" %}
@@ -145,6 +150,7 @@ nifi:
         - enable: True
         - watch:
             - nifi-config-properties
+            - increased security limits
 
 nifi-nginx-proxy:
     file.managed:


### PR DESCRIPTION
this is the change recommended by NiFi but further investigation into what it does reveals this:

> "Also, please note that all limit settings are set per login. They are not global, nor are they permanent; existing only for the duration of the session."
>\- https://linux.die.net/man/5/limits.conf

and neither Upstart (we're still mostly on 16.04 here) nor the processes it starts use a login session, so those limits are ignored.

this PR doesn't run through Alfred so I'm going to keep it open while I investigate further.

cc @giorgiosironi