### PR TITLE
Feature: clones the flow support repo

### DIFF
--- a/salt/data-pipeline/ejp-to-json-converter.sls
+++ b/salt/data-pipeline/ejp-to-json-converter.sls
@@ -42,6 +42,7 @@ temp dir symlink:
         - require:
             - ejp-to-json-converter repo
 
+# DEPRECATED. superceded by 'flow support repo' state in nifi.sls
 ejp-csv-deposit flow support repo:
     builder.git_latest:
         - name: git@github.com:elifesciences/data-pipeline-ejp-csv-deposit

--- a/salt/data-pipeline/nifi.sls
+++ b/salt/data-pipeline/nifi.sls
@@ -155,13 +155,26 @@ nifi-nginx-proxy:
         - watch_in:
             - service: nginx-server-service
 
-# transitionary, remove
-# these scripts are now in the flow support repository /opt/flows/ejp-csv-deposit
-nifi-script-dir-removed:
-    file.absent:
-        - name: {{ nifi_dir }}/scripts/
+flow support repo:
+    builder.git_latest:
+        - name: git@github.com:elifesciences/data-pipeline-flow-support
+        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - rev: master
+        - branch: master
+        - target: /opt/flow-support
+        - force_fetch: True
+        - force_checkout: True
+        - force_reset: True
+
+    file.directory:
+        - name:  /opt/flow-support
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - recurse:
+            - user
+            - group
         - require:
-            - download-nifi
+            - builder: flow support repo
 
 #
 # 


### PR DESCRIPTION
first of two PRs that sets up nifi for the transition and another to clean up after the transition has been made.

it's very safe by itself, just clones a new repo. the follow up will ensure the previous one is removed but only after nifi configuration is updated