### PR TITLE
Feature: added optional env param to update-big-query-wrapper

### DIFF
--- a/salt/data-pipeline/scripts/update-big-query-wrapper.sh
+++ b/salt/data-pipeline/scripts/update-big-query-wrapper.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # run as root
-set -e
+set -eu
+environment=${1:-{{ pillar.elife.env }}} # backwards compatibility: default to instance environment
 sudo -u elife --login /bin/bash << EOF
 cd /opt/data-pipeline-ejp-to-json-converter/
-DATA_PIPELINE_BQ_DATASET={{ pillar.elife.env }} ./update-big-query.sh
+DATA_PIPELINE_BQ_DATASET=$environment ./update-big-query.sh
 EOF
 #
 


### PR DESCRIPTION
the 'staging' version of the ejp-xml-deposit flow on the production data-pipeline instance needs the env var passed to it to update the correct the dataset in BQ