### PR TITLE
added gcs.json mount for gcp credentials

### DIFF
--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -9,7 +9,7 @@ bigquery-view docker image:
 re-materialise views daily:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
-        - name: docker run --rm -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
+        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
         - identifier: materialize-views-daily
         # at 1000 every day
         - hour: "10"


### PR DESCRIPTION
Not sure if we will still needed after making the latest changes but this should make the cronjob work.