### PR TITLE
Feature: process-zip-apply accepts environment parameter

### DIFF
--- a/salt/data-pipeline/ejp-to-json-converter.sls
+++ b/salt/data-pipeline/ejp-to-json-converter.sls
@@ -99,6 +99,7 @@ process file script:
         - source: salt://data-pipeline/scripts/process-zip-apply.sh
         - makedirs: True
         - mode: 740
+        - template: jinja
 
 # helper script that runs as update-big-query as the elife user
 update big query wrapper:


### PR DESCRIPTION
`ejp-to-json-converter` no longer shares same database for different flow environments

this affects the [ejp-xml-deposit staging flow](https://prod--pipeline.elifesciences.org/nifi/?processGroupId=01681048-851d-18cd-2a63-1bf109580a98&componentIds=e5958b65-0168-1000-473d-963aadaff4a2)