### PR TITLE
Feature: increases the size and path of the swap file.

### DIFF
--- a/salt/data-pipeline/nifi.sls
+++ b/salt/data-pipeline/nifi.sls
@@ -63,7 +63,11 @@ nifi-ext-dir:
         - name: {{ nifi_ext_dir }}
         - makedirs: True
         - require:
+            - mount-external-volume
             - download-nifi
+        # ensure /ext exists before creating swapspace in there
+        - require_in:
+            - make-swap-space
 
 # todo: there is configuration inside nifi referencing the '1.7.1' path. obviously not a good idea
 nifi-symlink:

--- a/salt/pillar/data-pipeline.sls
+++ b/salt/pillar/data-pipeline.sls
@@ -20,7 +20,7 @@ data_pipeline:
 
 elife:
     swap:
-        size: 512 # MB
+        path: /ext/swap.1
 
     web_users:
         nifi-registry-: # trailing hyphen not a typo


### PR DESCRIPTION
creation of /ext dir now depends on external volume being mounted and swapfile creation depends on creation of /ext dir + external volume being mounted

this is an attempt to ease some of the memory problems we're having when both ram + swap are maxed out. upgrading to a more capable instance will be the next option

cc @giorgiosironi 