### PR TITLE
Fix: backup script now understands new locations of certain directories

### DIFF
--- a/salt/data-pipeline/nifi.sls
+++ b/salt/data-pipeline/nifi.sls
@@ -221,6 +221,7 @@ nifi backup script:
         - template: jinja
         - defaults:
             nifi_dir: {{ nifi_dir }}
+            nifi_ext_dir: {{ nifi_ext_dir }}
             nifi_toolkit_dir: {{ nifi_toolkit_dir }}
             nifi_backup_dir: {{ backup_restore_dir }}
         - require:

--- a/salt/data-pipeline/nifi.sls
+++ b/salt/data-pipeline/nifi.sls
@@ -112,14 +112,21 @@ nifi-lib-symlink:
         - name: mv {{ nifi_dir }}/lib {{ nifi_ext_dir }}/lib
         - require:
             - nifi-ext-dir
-        - onlyif:
-            - test -d {{ nifi_dir }}/lib
+        - unless: # symlink already exists
+            - test -h {{ nifi_dir }}/lib
 
     file.symlink:
-        - name: /srv/nifi/lib
+        - name: {{ nifi_dir }}/lib
         - target: {{ nifi_ext_dir }}/lib
         - require:
             - cmd: nifi-lib-symlink
+
+# 2019-02-15: temporary state
+remove infinite lib symlink:
+    file.absent:
+        - name: {{ nifi_dir }}/lib/lib
+        - require:
+            - nifi-lib-symlink
 
 nifi-aws-properties:
     file.managed:

--- a/salt/data-pipeline/scripts/backup-nifi.sh
+++ b/salt/data-pipeline/scripts/backup-nifi.sh
@@ -18,16 +18,22 @@ else
     # maybe 100MB+
     mkdir -p {{ nifi_backup_dir }}
     (
+        # ignore these:
+        # state == runtime indexes of flowfiles
         cd {{ nifi_dir }}
-        
+        cp -R \
+            logs \
+            conf \
+            {{ nifi_backup_dir }}/
+    )
+
+    (
         # ignore these:
         # flowfile_repository == temporary flowfiles as they pass through this node
         # content_repository == flowfiles preserved for a certain amount of time in blobs
-        # state == runtime indexes of flowfiles
+        cd {{ nifi_ext_dir }}
         cp -R \
             provenance_repository \
-            logs \
-            conf \
             database_repository \
             {{ nifi_backup_dir }}/
     )


### PR DESCRIPTION
* backup script wasn't updated when the locations of certain directories were changed and was failing to copy them.
* bug with recursive `lib` dir symlinks causing an OOM before it caused the extra disk to fill up. backup dir would be purged the next day

cc @giorgiosironi 