### PR TITLE
re-materialise views hourly within working hours #5089

### DIFF
--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -10,9 +10,12 @@ re-materialise views hourly within working hours:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views-hourly
+        - identifier: materialize-views
         # materialized view hourly within working hours
         - hour: "6-19"
         - minute: "0"
         - require:
             - bigquery-view docker image
+
+    cron.absent:
+        - identifier: materialize-views-daily

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -12,8 +12,8 @@ re-materialise views daily:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
         - identifier: materialize-views-daily
-        # at 06:00am UTC every day
-        - hour: "6"
+        # materialized view hourly within working hours
+        - hour: "6-19"
         - minute: "0"
         - require:
             - bigquery-view docker image

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -17,5 +17,6 @@ re-materialise views hourly within working hours:
         - require:
             - bigquery-view docker image
 
+remove re-materialise views daily:
     cron.absent:
         - identifier: materialize-views-daily

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -20,4 +20,5 @@ re-materialise views hourly within working hours:
 remove re-materialise views daily:
     cron.absent:
         - user: {{ pillar.elife.deploy_user.username }}
+        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
         - identifier: materialize-views-daily

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -12,7 +12,7 @@ re-materialise views hourly within working hours:
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
         - identifier: materialize-views-hourly
         # materialized view hourly within working hours
-        - hour: "7-19"
+        - hour: "6-19"
         - minute: "0"
         - require:
             - bigquery-view docker image

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -6,13 +6,13 @@ bigquery-view docker image:
         - unless:
             - test -d /vagrant
 
-re-materialise views daily:
+re-materialise views hourly within working hours:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views-daily
-        # at 06:00am UTC every day
-        - hour: "6"
+        - identifier: materialize-views-hourly
+        # materialized view hourly within working hours
+        - hour: "7-19"
         - minute: "0"
         - require:
             - bigquery-view docker image

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -7,7 +7,7 @@ bigquery-view docker image:
         - unless:
             - test -d /vagrant
 
-re-materialise views daily:
+re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -15,8 +15,8 @@ re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views
-        # materialized view hourly within working hours
+        - identifier: materialise-views
+        # materialised view hourly within working hours
         - hour: "6-19"
         - minute: "0"
         - require:

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -1,3 +1,4 @@
+
 bigquery-view docker image:
     cmd.run:
         # pull but not if already present, to avoid accidental updates
@@ -6,19 +7,13 @@ bigquery-view docker image:
         - unless:
             - test -d /vagrant
 
-re-materialise views:
+re-materialise views daily:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views
-        # materialized view hourly within working hours
-        - hour: "6-19"
+        - identifier: materialize-views-daily
+        # at 06:00am UTC every day
+        - hour: "6"
         - minute: "0"
         - require:
             - bigquery-view docker image
-
-re-materialise views daily:
-    cron.absent:
-        - user: {{ pillar.elife.deploy_user.username }}
-        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views-daily

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -7,6 +7,10 @@ bigquery-view docker image:
         - unless:
             - test -d /vagrant
 
+re-materialise views daily:
+    cron.absent:
+        - identifier: materialize-views-daily
+
 re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -19,4 +19,5 @@ re-materialise views hourly within working hours:
 
 remove re-materialise views daily:
     cron.absent:
+        - user: {{ pillar.elife.deploy_user.username }}
         - identifier: materialize-views-daily

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -11,7 +11,7 @@ re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        - identifier: materialize-views-daily
+        - identifier: materialize-views
         # materialized view hourly within working hours
         - hour: "6-19"
         - minute: "0"

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -6,7 +6,7 @@ bigquery-view docker image:
         - unless:
             - test -d /vagrant
 
-re-materialise views hourly within working hours:
+re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
@@ -17,7 +17,7 @@ re-materialise views hourly within working hours:
         - require:
             - bigquery-view docker image
 
-remove re-materialise views daily:
+re-materialise views daily:
     cron.absent:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views


### PR DESCRIPTION
to address issue [#5089](https://github.com/elifesciences/issues/issues/5089), materialise views hourly within working hours as ejp now supports hourly data dump

for code review - @de-code @giorgiosironi 