### PR TITLE
#5228 Reconfigure cron job for view materialisation on staging server

### DIFF
--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -11,10 +11,15 @@ re-materialise views daily:
     cron.absent:
         - identifier: materialize-views-daily
 
+
 re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
+        {% if pillar.elife.env == "prod" %}
         - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
+        {% else %}
+        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views  --disable-view-name-mapping
+        {% endif %}
         - identifier: materialise-views
         # materialised view hourly within working hours
         - hour: "6-19"

--- a/salt/data-pipeline/bigquery-views.sls
+++ b/salt/data-pipeline/bigquery-views.sls
@@ -15,11 +15,7 @@ re-materialise views daily:
 re-materialise views:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
-        {% if pillar.elife.env == "prod" %}
-        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views
-        {% else %}
-        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views  --disable-view-name-mapping
-        {% endif %}
+        - name: docker run --rm -v /srv/nifi/conf/gcs.json:/root/.config/gcs.json -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcs.json -e DATA_PIPELINE_BQ_PROJECT=elife-data-pipeline elifesciences/data-pipeline-bigquery-views:{{ pillar.data_pipeline.bigquery_views.revision }} ./views-cli.sh --dataset={{ pillar.elife.env }} materialize-views {{ pillar.data_pipeline.bigquery_views.materialize_arguments }}
         - identifier: materialise-views
         # materialised view hourly within working hours
         - hour: "6-19"

--- a/salt/pillar/data-pipeline.sls
+++ b/salt/pillar/data-pipeline.sls
@@ -22,7 +22,7 @@ data_pipeline:
 
     bigquery_views:
         revision: latest
-        materialize_arguments:
+        materialize_arguments: ""
 
 elife:
     swap:

--- a/salt/pillar/data-pipeline.sls
+++ b/salt/pillar/data-pipeline.sls
@@ -22,7 +22,7 @@ data_pipeline:
 
     bigquery_views:
         revision: latest
-        materialize_arguments: ""
+        materialize_arguments: --disable-view-name-mapping
 
 elife:
     swap:

--- a/salt/pillar/data-pipeline.sls
+++ b/salt/pillar/data-pipeline.sls
@@ -22,6 +22,7 @@ data_pipeline:
 
     bigquery_views:
         revision: latest
+        materialize_arguments:
 
 elife:
     swap:


### PR DESCRIPTION
re-configure bigquery views data materialisation cron job for the staging server  such that it does not materialise views on bigquery staging dataset in the bigquery production dataset by adding `--disable-view-name-mapping` flag