### PR TITLE
salt 2019.2 upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('data-pipeline', '/srv/nifi')
+elifeFormula('data-pipeline', '/srv/nifi', null, ['snsalt'])


### PR DESCRIPTION
* jenkinsfile, adds a next-salt build

- [x] blocked by https://github.com/elifesciences/data-pipeline-ejp-to-json-converter/issues/114